### PR TITLE
New Feature: Custom functions on hitting both Y or Z endstops

### DIFF
--- a/fabui/application/layout/assets/js/fabtotum.js
+++ b/fabui/application/layout/assets/js/fabtotum.js
@@ -240,8 +240,8 @@ function safety() {
 	var timestamp = new Date().getTime();
 	if (EMERGENCY == false) {
 		$.get("/temp/fab_ui_safety.json?time=" + jQuery.now(), function(data) {
-			if (data.type == 'emergency') {
-				show_emergency(data.code);
+			if (data.type == 'emergency') {	
+                        	show_emergency(data.code);
 			}
 		});
 	}
@@ -414,7 +414,7 @@ $(function() {
 				switch(obj.type) {
 					
 				case 'emergency':
-					show_emergency(obj.code);
+                                       	show_emergency(obj.code);
 					break;
 				case 'security':
 					EMERGENCY = false;
@@ -796,6 +796,15 @@ function decode_emergency_code(code) {
 	case 109:
 		return 'Y min Endstop hit';
 		break;
+
+	case 120:
+		return 'Both Y Endstops hit at the same time';
+		break;
+
+	case 121:
+		return 'Both Z Endstops hit at the same time';
+		break;
+
 	default:
 		return 'Unknown error Error code: ' + code;
 		break;

--- a/fabui/application/modules/controller/ajax/shutdown.php
+++ b/fabui/application/modules/controller/ajax/shutdown.php
@@ -1,5 +1,5 @@
 <?php
-require_once $_SERVER['DOCUMENT_ROOT'] . '/lib/config.php';
+require_once '/var/www/lib/config.php';
 
 /** FORCE RESET CONTROLLER */
 $_command = 'sudo python '.PYTHON_PATH.'gmacro.py shutdown '.TEMP_PATH.'macro_trace '.TEMP_PATH.'macro_response'; 

--- a/fabui/application/modules/settings/ajax/general.php
+++ b/fabui/application/modules/settings/ajax/general.php
@@ -11,6 +11,9 @@ $_switch      = $_POST['switch'];
 $_feeder_disengage = $_POST['feeder_disengage_feeder'];
 $_feeder_extruder_steps_per_unit = $_POST['feeder_extruder_steps_per_unit'];
 
+$_both_y_endstops = $_POST['both_y_endstops'];
+$_both_z_endstops = $_POST['both_z_endstops'];
+
 $_colors['r'] = $_red;
 $_colors['g'] = $_green;
 $_colors['b'] = $_blue;
@@ -26,6 +29,8 @@ $_units['safety']['door'] = $_safety_door;
 $_units['switch']         = $_switch;
 $_units['feeder']         = $_feeder;
 $_units['e'] 		  = $_feeder_extruder_steps_per_unit;
+$_units['bothy']	  = $_both_y_endstops;
+$_units['bothz']	  = $_both_z_endstops;
 
 file_put_contents(FABUI_PATH.'config/config.json', json_encode($_units));
 

--- a/fabui/application/modules/settings/settings.php
+++ b/fabui/application/modules/settings/settings.php
@@ -29,13 +29,15 @@ class Settings extends Module {
 		
 		
 		$_units = json_decode(file_get_contents($this->config->item('fabtotum_config_units', 'fabtotum')), TRUE);
-        
+
         $data['_standby_color'] = $_units['color'];
 		$data['_safety_door']     = isset($_units['safety']['door']) ? $_units['safety']['door'] : '1';
 		$data['_switch']          = isset($_units['switch']) ? $_units['switch']: '0';
 		$data['_feeder_disengage'] = isset($_units['feeder']['disengage-offset']) ? $_units['feeder']['disengage-offset']: 2;
 		$data['_feeder_extruder_steps_per_unit'] = isset($_units['e']) ? $_units['e']: 3048.1593;
-        
+		$data['_both_y_endstops'] = isset($_units['bothy']) ? $_units['bothy']: "None";
+		$data['_both_z_endstops'] = isset($_units['bothz']) ? $_units['bothz']: "None";
+
         /** LOAD TAB HEADER */
         $_tab_header = $this->tab_header();
         

--- a/fabui/application/modules/settings/views/index/general/index.php
+++ b/fabui/application/modules/settings/views/index/general/index.php
@@ -3,14 +3,12 @@
 		<div class="col-md-12">
 			<div class="well no-border">
 				<form class="form-horizontal" action="<?php echo site_url('settings') ?>" method="post">
-					
 					<fieldset>
-						
 						<legend>
 							Safety - enable/disable warnings
 						</legend>
-						
-						<div class="form-group"> 
+
+						<div class="form-group">
 							<label class="col-md-2 control-label">
 								Door
 							</label>
@@ -27,13 +25,12 @@
 										<span>Disable</span>
 									</label>
 								</div>
-								
-								
+
+
 							</div>
 						</div>
 					</fieldset>
-					
-					
+
 					<fieldset>
 						<legend>Homing preferences</legend>
 						<div class="form-group">
@@ -53,9 +50,33 @@
 								</div>
 							</div>
 						</div>
-						
 					</fieldset>
-					
+
+					<fieldset>
+						<legend>Customized input actions</legend>
+						<div class="form-group">
+							<label class="col-md-2 control-label">Both Y Endstops pressed</label>
+							<div class="col-md-10">
+								 <select id="both-y-endstops">
+									  <option value="None" <?php echo $_both_y_endstops == 'None' ? 'selected="selected"' : '' ?> >None</option>
+									  <option value="Shutdown" <?php echo $_both_y_endstops == 'Shutdown' ? 'selected="selected"' : '' ?> >Shutdown</option>
+								</select> 
+							</div>
+						</div>
+						<div class="form-group">
+							<label class="col-md-2 control-label">Both Z Endstops pressed</label>
+							<div class="col-md-10">
+								 <select id="both-z-endstops">
+									  <option value="None" <?php echo $_both_z_endstops == 'None' ? 'selected="selected"' : '' ?> >None</option>
+									  <option value="Shutdown" <?php echo $_both_z_endstops == 'Shutdown' ? 'selected="selected"' : '' ?> >Shutdown</option>
+								</select> 
+							</div>
+						</div>
+						<div><b>Warning: You have to restart the FABtotum so that some customized input actions take effect</b>
+						</div>
+					</fieldset>
+
+
 					<fieldset>
 						<legend>Feeder</legend>
 						<div class="form-group">
@@ -71,7 +92,7 @@
 							</div>
 						</div>
 					</fieldset>
-					
+
 					<fieldset>
 						<legend>
 							Lighting
@@ -96,7 +117,7 @@
 							<input name="standby-color-green" id="standby-color-green" type="hidden" value="<?php echo $_standby_color['g'] != '' ? $_standby_color['g'] : 0 ?>"/>
 							<input name="standby-color-blue"  id="standby-color-blue"  type="hidden" value="<?php echo $_standby_color['b'] != '' ? $_standby_color['b'] : 0 ?>"/>
 						</div>
-                        
+
 					</fieldset>
 					<div class="form-actions">
 						<button id="save-button" class="btn btn-primary" type="button">

--- a/fabui/application/modules/settings/views/index/general/js.php
+++ b/fabui/application/modules/settings/views/index/general/js.php
@@ -126,8 +126,15 @@ function save(){
         url : '<?php echo module_url('settings').'ajax/general.php' ?>',
 		  dataType : 'json',
 		  type: 'post',
-          data: {red : $("#red").val(), green: $("#green").val(), blue: $("#blue").val(), 
-          		safety_door: $('[name="safety-door"]:checked').val(), switch:$('[name="switch"]:checked').val(), feeder_disengage_feeder: $("#feeder-disengage-offset").val(), feeder_extruder_steps_per_unit: $("#feeder-extruder-steps-per-unit").val()},
+          data: {
+			red : $("#red").val(), green: $("#green").val(), blue: $("#blue").val(), 
+          		safety_door: $('[name="safety-door"]:checked').val(), 
+			switch:$('[name="switch"]:checked').val(), 
+			feeder_disengage_feeder: $("#feeder-disengage-offset").val(), 
+			feeder_extruder_steps_per_unit: $("#feeder-extruder-steps-per-unit").val(),
+			both_y_endstops: $("#both-y-endstops").val(),
+			both_z_endstops: $("#both-z-endstops").val()
+		},
           dataType: 'json'
 		}).done(function(response) {
 			

--- a/fabui/python/monitor.py
+++ b/fabui/python/monitor.py
@@ -10,6 +10,8 @@ import RPi.GPIO as GPIO
 import logging
 import os, sys
 
+from subprocess import call
+
 
 monitorPID = os.getpid()
 
@@ -55,6 +57,10 @@ GPIO.cleanup()
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(2, GPIO.IN, pull_up_down = GPIO.PUD_DOWN)
 
+'''### READ PRINTER SETTINGS ###'''
+json_f = open(config.get('printer', 'settings_file'))
+units = json.load(json_f)
+
 
 def write_emergency(str):        
     safety = open(safety_file, 'w+')
@@ -85,10 +91,24 @@ def safety_callback(channel):
             #to do
             type=""
             code=""
-                
-        message = {'type': str(type), 'code': str(code)}
-        ws.send(json.dumps(message))
-        write_emergency(json.dumps(message))
+
+	print units['bothy']
+	print type
+	print code
+
+	if (units['bothy']=="Shutdown" and type=="emergency" and int(code)==120):
+		call (['sudo php /var/www/fabui/application/modules/controller/ajax/shutdown.php'], shell=True)
+		return
+
+	if (units['bothz']=="Shutdown" and type=="emergency" and int(code)==121):
+		call (['sudo php /var/www/fabui/application/modules/controller/ajax/shutdown.php'], shell=True)
+		return
+
+       	message = {'type': str(type), 'code': str(code)}		
+
+       	ws.send(json.dumps(message))
+       	write_emergency(json.dumps(message))
+
         
     except Exception, e:
         logging.info(str(e))


### PR DESCRIPTION
=============================================================

This FAB-UI functionality is linked to a still unmerged FABlin pull-request and will not work without it.

It provides flexibility to interact with FABUI directly from the FABtotum, without the need of a client browser.

Currently only "shutdown" is implemented. For it to work you have to select it under settings and restart your FABtotum.

The Settings implementation allows for selection of the action to be undertaken. Currently only shutdown is implemented.