### PR TITLE
Added option to disable Z-probe during homing

### DIFF
--- a/fabui/application/modules/settings/ajax/general.php
+++ b/fabui/application/modules/settings/ajax/general.php
@@ -19,6 +19,8 @@ $_feeder_extruder_steps_per_unit_e_mode = $_POST['feeder_extruder_steps_per_unit
 $_both_y_endstops                       = $_POST['both_y_endstops'];
 $_both_z_endstops                       = $_POST['both_z_endstops'];
 $_upload_api_key                        = $_POST['upload_api_key'];
+$_zprobe                             	= $_POST['zprobe'];
+$_zmax									= $_POST['zmax'];
 
 $_colors['r'] = $_red;
 $_colors['g'] = $_green;
@@ -39,6 +41,8 @@ $_units['feeder']                               = $_feeder;
 $_units['bothy']	                            = $_both_y_endstops;
 $_units['bothz']	                            = $_both_z_endstops;
 $_units['api']['keys'][$_SESSION['user']['id']] = $_upload_api_key;
+$_units['zprobe']['disable']                    = $_zprobe;
+$_units['zprobe']['zmax']                    	= $_zmax;
 
 file_put_contents(FABUI_PATH.'config/config.json', json_encode($_units));
 

--- a/fabui/application/modules/settings/settings.php
+++ b/fabui/application/modules/settings/settings.php
@@ -39,6 +39,8 @@ class Settings extends Module {
 		$data['_both_y_endstops']                       = isset($_units['bothy']) ? $_units['bothy']: "None";
 		$data['_both_z_endstops']                       = isset($_units['bothz']) ? $_units['bothz']: "None";
 		$data['_upload_api_key']                        = isset($_units['api']['keys'][$_SESSION['user']['id']]) ? $_units['api']['keys'][$_SESSION['user']['id']]: '';
+		$data['_zprobe']								= isset($_units['zprobe']['disable']) ? $_units['zprobe']['disable']: '0';
+		$data['_zmax']									= isset($_units['zprobe']['zmax']) ? $_units['zprobe']['zmax']: '206';
 		
 		
         /** LOAD TAB HEADER */

--- a/fabui/application/modules/settings/views/index/general/index.php
+++ b/fabui/application/modules/settings/views/index/general/index.php
@@ -47,6 +47,25 @@
 								</div>
 							</div>
 						</div>
+						<div class="form-group">
+							<label class="col-md-2 control-label">Z-Probe</label>
+							<div class="col-md-2">
+								<div class="radio">
+									<label>
+										<input type="radio" class="radiobox style-0" name="zprobe" value="0" <?php echo $_zprobe == '0' ? 'checked="checked"' : '' ?>>
+										<span>Enable</span> </label>
+								</div>
+								<div class="radio">
+									<label>
+										<input type="radio" class="radiobox style-0" name="zprobe" value="1" <?php echo $_zprobe == '1' ? 'checked="checked"' : '' ?>>
+										<span>Disable</span> </label>
+								</div>
+							</div>
+							<label class="col-md-2 control-label">Z Max Home Pos (mm)</label>
+							<div class="col-md-6">
+								<input class="form-control"  type="text" id="zmax-homing" value="<?php echo $_zmax; ?>">
+							</div>
+						</div>
 
 					</fieldset>
 

--- a/fabui/application/modules/settings/views/index/general/js.php
+++ b/fabui/application/modules/settings/views/index/general/js.php
@@ -133,7 +133,9 @@ function save(){
           		feeder_extruder_steps_per_unit_a_mode: $("#feeder-extruder-steps-per-unit-a").val(),*/
           		both_y_endstops: $("#both-y-endstops").val(),
           		both_z_endstops: $("#both-z-endstops").val(),
-          		upload_api_key: $("#upload-api-key").val()},
+          		upload_api_key: $("#upload-api-key").val(),
+          		zmax:$('#zmax-homing').val(),
+          		zprobe:$('[name="zprobe"]:checked').val()},
           dataType: 'json'
 		}).done(function(response) {
 			
@@ -161,6 +163,13 @@ $("#feeder-disengage-offset").spinner({
 				min: 0,
 				max: 6
 		});
+
+$("#zmax-homing").spinner({
+	step :0.05,
+	numberFormat : "n",
+	min: 150,
+	max: 250
+});
 
 /*
 $("#feeder-extruder-steps-per-unit").spinner({


### PR DESCRIPTION
Added option to disable Z-probe and use Z-max endstop during homing from Jog menu and before printing.
![screenshot from 2015-07-21 20 37 16](https://cloud.githubusercontent.com/assets/10041611/8800954/9a281514-2fe9-11e5-9345-b6084957804c.png)
