### PR TITLE
Bug fix: fan slider starting at 0, not at 50%

### DIFF
--- a/fabui/application/modules/create/views/index/js.php
+++ b/fabui/application/modules/create/views/index/js.php
@@ -250,7 +250,7 @@
         });
         
         $("#fan").noUiSlider({
-		        range: {'min': 50, 'max' : 100},
+		        range: {'min': 0, 'max' : 100},
                 /*range: [0, 500],*/
                	start: 255,
 		        handles: 1,


### PR DESCRIPTION
Allow to stop the fan during print by the user using the slider.

It is unreasonable not to be able to allow the user to do this. One thing is to guide a user towards sensible actions and another is to prevent a user from doing something he should be able to do. If there is a reasonable fear that clogged nozzles happen because of users switching the fan off, then the UI may be used to warn the user or even require confirmation that he actually wants to set it to 0.