### PR TITLE
Fixed typo in feeder calibration widget

### DIFF
--- a/fabui/application/modules/maintenance/views/feedercalibration/widget.php
+++ b/fabui/application/modules/maintenance/views/feedercalibration/widget.php
@@ -16,7 +16,7 @@
 					</section>
 				</div>
 			</fieldset>
-			<header>Misure and calibrate extruder steps</header>
+			<header>Measure and calibrate extruder steps</header>
 			<fieldset>
 				<div class="row">
 					<section class="col col-8">


### PR DESCRIPTION
Misure might be correct Italien, but in English it's measure.